### PR TITLE
Capture the user's access token and secret so we can tweet for them

### DIFF
--- a/lib/passport-twitter/strategy.js
+++ b/lib/passport-twitter/strategy.js
@@ -46,10 +46,10 @@ function Strategy(options, verify) {
   options.accessTokenURL = options.accessTokenURL || 'https://api.twitter.com/oauth/access_token';
   options.userAuthorizationURL = options.userAuthorizationURL || 'https://api.twitter.com/oauth/authenticate';
   options.sessionKey = options.sessionKey || 'oauth:twitter';
-  
+
   OAuthStrategy.call(this, options, verify);
   this.name = 'twitter';
-  
+
   this._skipExtendedUserProfile = (options.skipExtendedUserProfile === undefined) ? false : options.skipExtendedUserProfile;
 }
 
@@ -77,7 +77,7 @@ Strategy.prototype.authenticate = function(req, options) {
   if (req.query && req.query.denied) {
     return this.fail();
   }
-  
+
   // Call the base class for standard OAuth authentication.
   OAuthStrategy.prototype.authenticate.call(this, req, options);
 }
@@ -105,19 +105,26 @@ Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
   if (!this._skipExtendedUserProfile) {
     this._oauth.get('https://api.twitter.com/1/users/show.json?user_id=' + params.user_id, token, tokenSecret, function (err, body, res) {
       if (err) { return done(new InternalOAuthError('failed to fetch user profile', err)); }
-      
+
       try {
         var json = JSON.parse(body);
-      
+
         var profile = { provider: 'twitter' };
+
         profile.id = json.id;
         profile.username = json.screen_name;
         profile.displayName = json.name;
         profile.photos = [{ value: json.profile_image_url_https }];
-      
+
+        // These allow us to tweet on the user's behalf, etc. via
+        // ntwitter or similar (if the app was registered with
+        // those permissions)
+        profile.token = token;
+        profile.tokenSecret = tokenSecret;
+
         profile._raw = body;
         profile._json = json;
-      
+
         done(null, profile);
       } catch(e) {
         done(e);


### PR DESCRIPTION
This is a super-common use case for twitter login, and if it doesn't get captured at authentication time it pretty much won't be, so it makes sense to record this information in the profile. Thanks!
