### PR TITLE
Adding profile url for consistency

### DIFF
--- a/lib/profile.js
+++ b/lib/profile.js
@@ -15,6 +15,7 @@ exports.parse = function(json) {
   if (json.id_str) { profile.id = json.id_str; }
   profile.username = json.screen_name;
   profile.displayName = json.name;
+  profile.profileUrl = "https://twitter.com/" + profile.username;
   profile.photos = [{ value: json.profile_image_url_https }];
   
   return profile;

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -34,6 +34,7 @@ describe('Strategy#userProfile', function() {
       expect(profile.id).to.equal('6253282');
       expect(profile.username).to.equal('twitterapi');
       expect(profile.displayName).to.equal('Twitter API');
+      expect(profile.profileUrl).to.equal('https://twitter.com/twitterapi');
       expect(profile.photos[0].value).to.equal('https://si0.twimg.com/profile_images/1438634086/avatar_normal.png');
     });
     


### PR DESCRIPTION
Social networks strategies (like Facebook or VK) have a user profile url in the profile object. Added the same behavior to twitter strategy.