### PR TITLE
Specifying the express version to avoid the express.createServer() error...

### DIFF
--- a/examples/signin/package.json
+++ b/examples/signin/package.json
@@ -2,7 +2,7 @@
   "name": "passport-twitter-examples-signin",
   "version": "0.0.0",
   "dependencies": {
-    "express": ">= 0.0.0",
+    "express": "^3.0.0",
     "ejs": ">= 0.0.0",
     "passport": ">= 0.0.0",
     "passport-twitter": ">= 0.0.0"


### PR DESCRIPTION
I noticed that the example won't run properly without specifying the express version to 3.0.0.

Error: 
1234-osx:signin hans_li$ node app.js
/somewhere/passport-twitter/examples/signin/app.js:51
var app = express.createServer();
                  ^
TypeError: undefined is not a function
    at Object.<anonymous> (/somewhere/passport-twitter/examples/signin/app.js:51:19)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3

The error was corrected after specifying the express version to 3.0.0 and running a 'npm install' in the signin directory.

Thanks,
Hans
