### PR TITLE
Possibility to verify credentials for the apps whitelisted by Twitter.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -29,8 +29,33 @@ var parse = require('./profile').parse
  *
  *     passport.use(new TwitterStrategy({
  *         consumerKey: '123-456-789',
- *         consumerSecret: 'shhh-its-a-secret'
+ *         consumerSecret: 'shhh-its-a-secret',
  *         callbackURL: 'https://www.example.net/auth/twitter/callback'
+ *       },
+ *       function(token, tokenSecret, profile, done) {
+ *         User.findOrCreate(..., function (err, user) {
+ *           done(err, user);
+ *         });
+ *       }
+ *     ));
+ *
+ * If your application is whitelisted by Twitter you may request additional credentials to be provided,
+ * like users e-mail addresses.
+ *
+ * Reference: https://dev.twitter.com/rest/reference/get/account/verify_credentials
+ *
+ * Example of using twitter-passport to verify credentials:
+ *
+ * Options:
+ *   - `scope`  the array of parameters to request. Possible options: `include_entities`, `skip_status`, `include_email`
+ *
+ * Example:
+ *
+ *   passport.use(new TwitterStrategy({
+ *         consumerKey: '123-456-789',
+ *         consumerSecret: 'shhh-its-a-secret',
+ *         callbackURL: 'https://www.example.net/auth/twitter/callback',
+ *         scope: ['include_email']
  *       },
  *       function(token, tokenSecret, profile, done) {
  *         User.findOrCreate(..., function (err, user) {
@@ -52,8 +77,12 @@ function Strategy(options, verify) {
   
   OAuthStrategy.call(this, options, verify);
   this.name = 'twitter';
+  this._scope = options.scope;
   this._userProfileURL = options.userProfileURL || 'https://api.twitter.com/1.1/users/show.json';
+  this._verifyCredentialsURL = options.verifyCredentialsURL || 'https://api.twitter.com/1.1/account/verify_credentials.json';
+  this._verifyCredentials = (options.scope !== undefined);
   this._skipExtendedUserProfile = (options.skipExtendedUserProfile !== undefined) ? options.skipExtendedUserProfile : false;
+
 }
 
 /**
@@ -107,8 +136,22 @@ Strategy.prototype.authenticate = function(req, options) {
 Strategy.prototype.userProfile = function(token, tokenSecret, params, done) {
   if (!this._skipExtendedUserProfile) {
     var json;
-    
-    this._oauth.get(this._userProfileURL + '?user_id=' + params.user_id, token, tokenSecret, function (err, body, res) {
+    var userProfileURL;
+    if (this._verifyCredentials) {
+      userProfileURL = this._verifyCredentialsURL;
+      if (this._scope) {
+        if (Array.isArray(this._scope)) {
+          var params = [];
+          for(var key in this._scope) {
+            params.push(this._scope[key] + '=true');
+          }
+          userProfileURL = userProfileURL + '?' +  params.join("&");
+        }
+      }
+    } else {
+      userProfileURL = this._userProfileURL + '?user_id=' + params.user_id;
+    }
+    this._oauth.get(userProfileURL, token, tokenSecret, function (err, body, res) {
       if (err) {
         if (err.data) {
           try {


### PR DESCRIPTION
Added the possibility to request **verify_credentials** with passport-twitter while authenticating.

Reference: https://dev.twitter.com/rest/reference/get/account/verify_credentials

Verify credentials may be used for example for requesting the users e-mail addresses for the whitelisted apps. 
Currently Twitter supports the following parameters: `include_entities`, `skip_status`, `include_email`, all optional.

Example: 

        passport.use(new TwitterStrategy({
            consumerKey: '123-456-789',
            consumerSecret: 'shhh-its-a-secret',
            callbackURL: 'https://www.example.net/auth/twitter/callback',
            scope: ['include_email']
        },
        function(token, tokenSecret, profile, done) {
          User.findOrCreate(..., function (err, user) {
              done(err, user);
          });
        }));
