### PR TITLE
feat: use safe version of xmldom and mocha

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -2,7 +2,7 @@
 var OAuthStrategy = require('passport-oauth1')
   , util = require('util')
   , uri = require('url')
-  , XML = require('xtraverse')
+  , { DOMParser } = require('@xmldom/xmldom')
   , Profile = require('./profile')
   , InternalOAuthError = require('passport-oauth1').InternalOAuthError
   , APIError = require('./errors/apierror');
@@ -193,17 +193,17 @@ Strategy.prototype.userAuthorizationParams = function(options) {
  * @return {Error}
  * @access protected
  */
-Strategy.prototype.parseErrorResponse = function(body, status) {
-  var json, xml;
-  
+Strategy.prototype.parseErrorResponse = function (body, _status) {
   try {
-    json = JSON.parse(body);
+    const json = JSON.parse(body);
     if (Array.isArray(json.errors) && json.errors.length > 0) {
       return new Error(json.errors[0].message);
     }
   } catch (ex) {
-    xml = XML(body)
-    return new Error(xml.children('error').t() || body);
+    const xml = new DOMParser().parseFromString(body, 'text/xml');
+    const error = xml.getElementsByTagName('error');
+
+    return new Error(error.item(0)?.textContent || body);
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   ],
   "main": "./lib",
   "dependencies": {
-    "passport-oauth1": "1.x.x",
-    "xtraverse": "0.1.x"
+    "@xmldom/xmldom": "^0.8.10",
+    "passport-oauth1": "1.x.x"
   },
   "devDependencies": {
     "make-node": "0.4.6",
-    "mocha": "2.x.x",
+    "mocha": "10.4.0",
     "chai": "2.x.x",
     "chai-passport-strategy": "1.x.x"
   },


### PR DESCRIPTION
** READ THIS FIRST! **

#### Are you implementing a new feature?
n/a

#### Is this a security patch?

Removes dependency on xtraverse and uses safer version of `xmldom` to handle the fallback in parseErrorResponse.

Updates mocha to safe version with no critical vulnerabilites.

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport-twitter/blob/master/CONTRIBUTING.md) guidelines.
- [ ] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
