### PR TITLE
Updates url to use X domain

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -45,14 +45,14 @@ var OAuthStrategy = require('passport-oauth1')
  */
 function Strategy(options, verify) {
   options = options || {};
-  options.requestTokenURL = options.requestTokenURL || 'https://api.twitter.com/oauth/request_token';
-  options.accessTokenURL = options.accessTokenURL || 'https://api.twitter.com/oauth/access_token';
-  options.userAuthorizationURL = options.userAuthorizationURL || 'https://api.twitter.com/oauth/authenticate';
+  options.requestTokenURL = options.requestTokenURL || 'https://api.x.com/oauth/request_token';
+  options.accessTokenURL = options.accessTokenURL || 'https://api.x.com/oauth/access_token';
+  options.userAuthorizationURL = options.userAuthorizationURL || 'https://api.x.com/oauth/authenticate';
   options.sessionKey = options.sessionKey || 'oauth:twitter';
   
   OAuthStrategy.call(this, options, verify);
   this.name = 'twitter';
-  this._userProfileURL = options.userProfileURL || 'https://api.twitter.com/1.1/account/verify_credentials.json';
+  this._userProfileURL = options.userProfileURL || 'https://api.x.com/1.1/account/verify_credentials.json';
   this._skipExtendedUserProfile = (options.skipExtendedUserProfile !== undefined) ? options.skipExtendedUserProfile : false;
   this._includeEmail = (options.includeEmail !== undefined) ? options.includeEmail : false;
   this._includeStatus = (options.includeStatus !== undefined) ? options.includeStatus : true;

--- a/test/fixtures/account/theSeanCook-include_email.json
+++ b/test/fixtures/account/theSeanCook-include_email.json
@@ -89,7 +89,7 @@
             "id": "866269c983527d5a",
             "name": "Ashbury Heights",
             "place_type": "neighborhood",
-            "url": "http://api.twitter.com/1/geo/id/866269c983527d5a.json"
+            "url": "http://api.x.com/1/geo/id/866269c983527d5a.json"
         },
         "retweet_count": 0,
         "retweeted": false,

--- a/test/fixtures/account/theSeanCook.json
+++ b/test/fixtures/account/theSeanCook.json
@@ -88,7 +88,7 @@
             "id": "866269c983527d5a",
             "name": "Ashbury Heights",
             "place_type": "neighborhood",
-            "url": "http://api.twitter.com/1/geo/id/866269c983527d5a.json"
+            "url": "http://api.x.com/1/geo/id/866269c983527d5a.json"
         },
         "retweet_count": 0,
         "retweeted": false,

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -11,7 +11,7 @@ describe('Strategy#userProfile', function() {
     }, function verify(){});
     
     strategy._oauth.get = function(url, token, tokenSecret, callback) {
-      if (url != 'https://api.twitter.com/1.1/account/verify_credentials.json') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://api.x.com/1.1/account/verify_credentials.json') { return callback(new Error('incorrect url argument')); }
       if (token != 'token') { return callback(new Error('incorrect token argument')); }
       if (tokenSecret != 'token-secret') { return callback(new Error('incorrect tokenSecret argument')); }
     
@@ -60,7 +60,7 @@ describe('Strategy#userProfile', function() {
     }, function verify(){});
     
     strategy._oauth.get = function(url, token, tokenSecret, callback) {
-      if (url != 'https://api.twitter.com/1.1/account/verify_credentials.json?include_email=true') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://api.x.com/1.1/account/verify_credentials.json?include_email=true') { return callback(new Error('incorrect url argument')); }
       if (token != 'token') { return callback(new Error('incorrect token argument')); }
       if (tokenSecret != 'token-secret') { return callback(new Error('incorrect tokenSecret argument')); }
     
@@ -109,7 +109,7 @@ describe('Strategy#userProfile', function() {
     }, function verify(){});
     
     strategy._oauth.get = function(url, token, tokenSecret, callback) {
-      if (url != 'https://api.twitter.com/1.1/account/verify_credentials.json?skip_status=true') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://api.x.com/1.1/account/verify_credentials.json?skip_status=true') { return callback(new Error('incorrect url argument')); }
       if (token != 'token') { return callback(new Error('incorrect token argument')); }
       if (tokenSecret != 'token-secret') { return callback(new Error('incorrect tokenSecret argument')); }
     
@@ -158,7 +158,7 @@ describe('Strategy#userProfile', function() {
     }, function verify(){});
     
     strategy._oauth.get = function(url, token, tokenSecret, callback) {
-      if (url != 'https://api.twitter.com/1.1/account/verify_credentials.json?include_entities=false') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://api.x.com/1.1/account/verify_credentials.json?include_entities=false') { return callback(new Error('incorrect url argument')); }
       if (token != 'token') { return callback(new Error('incorrect token argument')); }
       if (tokenSecret != 'token-secret') { return callback(new Error('incorrect tokenSecret argument')); }
     
@@ -203,11 +203,11 @@ describe('Strategy#userProfile', function() {
     var strategy = new TwitterStrategy({
       consumerKey: 'ABC123',
       consumerSecret: 'secret',
-      userProfileURL: 'https://api.twitter.com/1.1/users/show.json'
+      userProfileURL: 'https://api.x.com/1.1/users/show.json'
     }, function verify(){});
     
     strategy._oauth.get = function(url, token, tokenSecret, callback) {
-      if (url != 'https://api.twitter.com/1.1/users/show.json?user_id=6253282') { return callback(new Error('incorrect url argument')); }
+      if (url != 'https://api.x.com/1.1/users/show.json?user_id=6253282') { return callback(new Error('incorrect url argument')); }
       if (token != 'token') { return callback(new Error('incorrect token argument')); }
       if (tokenSecret != 'token-secret') { return callback(new Error('incorrect tokenSecret argument')); }
     
@@ -290,7 +290,7 @@ describe('Strategy#userProfile', function() {
     var strategy = new TwitterStrategy({
       consumerKey: 'ABC123',
       consumerSecret: 'secret',
-      userProfileURL: 'https://api.twitter.com/1.1/users/show.json'
+      userProfileURL: 'https://api.x.com/1.1/users/show.json'
     }, function verify(){});
     
     strategy._oauth.get = function(url, token, tokenSecret, callback) {
@@ -326,7 +326,7 @@ describe('Strategy#userProfile', function() {
     var strategy = new TwitterStrategy({
       consumerKey: 'ABC123',
       consumerSecret: 'secret',
-      userProfileURL: 'https://api.twitter.com/1.1/users/show.json'
+      userProfileURL: 'https://api.x.com/1.1/users/show.json'
     }, function verify(){});
     
     strategy._oauth.get = function(url, token, tokenSecret, callback) {
@@ -359,7 +359,7 @@ describe('Strategy#userProfile', function() {
     var strategy = new TwitterStrategy({
       consumerKey: 'ABC123',
       consumerSecret: 'secret',
-      userProfileURL: 'https://api.twitter.com/1.1/users/show.json'
+      userProfileURL: 'https://api.x.com/1.1/users/show.json'
     }, function verify(){});
     
     strategy._oauth.get = function(url, token, tokenSecret, callback) {

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -49,7 +49,7 @@ describe('Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://api.twitter.com/oauth/authenticate?oauth_token=hh5s93j4hdidpola');
+      expect(url).to.equal('https://api.x.com/oauth/authenticate?oauth_token=hh5s93j4hdidpola');
     });
   });
   
@@ -79,7 +79,7 @@ describe('Strategy', function() {
     });
   
     it('should be redirected', function() {
-      expect(url).to.equal('https://api.twitter.com/oauth/authenticate?oauth_token=hh5s93j4hdidpola&force_login=true&screen_name=bob');
+      expect(url).to.equal('https://api.x.com/oauth/authenticate?oauth_token=hh5s93j4hdidpola&force_login=true&screen_name=bob');
     });
   });
   


### PR DESCRIPTION
New twitter api changes require to use X domain,
Using `api.twitter` causes some redirects issues preventing switching accounts and various other issues on mobile

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [ ] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport-twitter/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [ ] I have added documentation pertaining to this feature or patch.
- [ ] The automated test suite (`$ make test`) executes successfully.
- [ ] The automated code linting (`$ make lint`) executes successfully.
